### PR TITLE
Dev

### DIFF
--- a/components/PostSingle.tsx
+++ b/components/PostSingle.tsx
@@ -63,9 +63,9 @@ export default function PostSingle({ post }: { post: Post }) {
         />
         {post.tag.map((tag, index) => {
           return (
-            <Link href="/" key={`tag_${tag}`}>
+            <Link href="/" key={`tag_${tag.id}`}>
               <p className="px-1 ml-1 cursor-pointer self-auto text-lg border-b-2 border-white hover:border-gray-400 hover:text-gray-400">
-                {index > 0 ? ", " + tag : tag}
+                {index > 0 ? ", " + tag.name : tag.name}
               </p>
             </Link>
           );

--- a/components/PostThumbnail.tsx
+++ b/components/PostThumbnail.tsx
@@ -15,7 +15,7 @@ export default function PostThumbnail({ post }: { post: Post }) {
           <Image src={post.thumbnail} width={480} height={270} />
           <Link href="/">
             <p className="absolute top-1 left-2 py-0.5 px-2 rounded-full bg-accent cursor-pointer text-sm text-black">
-              {post.category}
+              {post.category.name}
             </p>
           </Link>
           <p className="p-1 text-xl">{"　" + post.title}</p>

--- a/components/PostThumbnail.tsx
+++ b/components/PostThumbnail.tsx
@@ -24,10 +24,10 @@ export default function PostThumbnail({ post }: { post: Post }) {
               <Image src="/images/tag_icon.png" width={20} height={12} />
               {post.tag.map((tag, index) => {
                 return (
-                  <Link href="/" key={tag}>
+                  <Link href="/" key={tag.id}>
                     <p className="px-1 ml-1 cursor-pointer">
                       {" "}
-                      {index > 0 ? ", " + tag : tag}
+                      {index > 0 ? ", " + tag.name : tag.name}
                     </p>
                   </Link>
                 );

--- a/firebase/dbFunctions.ts
+++ b/firebase/dbFunctions.ts
@@ -34,6 +34,21 @@ const getTagsById = async (ids: string[]) => {
   return tags_result;
 };
 
+// idを指定して、カテゴリーを獲得。
+const getCategoryById = async (id: string) => {
+  const DB: FirebaseFirestore.Firestore = admin.firestore();
+  const categories = await DB.collection("categories").get();
+  for (let category of categories.docs) {
+    if (category.id == id)
+      return {
+        id: category.id,
+        name: category.data().name,
+      };
+  }
+
+  return { id: id, name: id };
+};
+
 // idを指定して一つ記事を獲得。
 export const getPost = async (id: string) => {
   const DB = admin.firestore();
@@ -53,7 +68,7 @@ export const getPost = async (id: string) => {
     createTime: post_data.createTime.toDate(),
     updateTime: post_data.updateTime.toDate(),
     tag: await getTagsById(post_data.tag),
-    category: post_data.category,
+    category: await getCategoryById(post_data.category),
     public: post_data.public,
     thumbnail: post_data.thumbnail
       ? post_data.thumbnail
@@ -124,7 +139,7 @@ export const getAllPosts = async (
       createTime: post_data.createTime.toDate(),
       updateTime: post_data.updateTime.toDate(),
       tag: await getTagsById(post_data.tag),
-      category: post_data.category,
+      category: await getCategoryById(post_data.category),
       public: post_data.public,
       thumbnail: post_data.thumbnail
         ? post_data.thumbnail

--- a/firebase/dbFunctions.ts
+++ b/firebase/dbFunctions.ts
@@ -9,6 +9,60 @@ import admin from "./firebase_init";
 // これを使ってページング。
 export const page_posts = 2;
 
+// idを配列で指定してタグの配列を獲得。
+const getTagsById = async (ids: string[]) => {
+  const DB: FirebaseFirestore.Firestore = admin.firestore();
+  let tags_result: Tag[] = [];
+
+  const tags = await DB.collection("tags").get();
+
+  for (let group of tags.docs) {
+    await group.ref
+      .collection("children")
+      .get()
+      .then((tags) => {
+        tags.forEach((tag) => {
+          ids.forEach((id) => {
+            if (tag.id == id) {
+              tags_result.push({ id: tag.id, name: tag.data().name });
+            }
+          });
+        });
+      });
+  }
+
+  return tags_result;
+};
+
+// idを指定して一つ記事を獲得。
+export const getPost = async (id: string) => {
+  const DB = admin.firestore();
+  const snapshot = await DB.collection("posts").doc(id).get();
+
+  //記事が存在しない場合エラーを投げる。
+  if (snapshot.empty) {
+    throw "post not found";
+  }
+
+  const post_data = snapshot.data();
+
+  const post: Post = {
+    id: snapshot.id,
+    title: post_data.title,
+    body: post_data.body,
+    createTime: post_data.createTime.toDate(),
+    updateTime: post_data.updateTime.toDate(),
+    tag: await getTagsById(post_data.tag),
+    category: post_data.category,
+    public: post_data.public,
+    thumbnail: post_data.thumbnail
+      ? post_data.thumbnail
+      : "/images/no_image.png",
+  };
+
+  return post;
+};
+
 // 記事の一覧を渡す。
 // クエリ処理を引数で指定することが出来る。クエリの指定方法はwhere()と同じく、
 // (対象の属性, 演算子, 値)の形式。 参照(https://firebase.google.com/docs/firestore/query-data/queries?authuser=0)
@@ -17,14 +71,18 @@ export const page_posts = 2;
 // ページを設定しない場合は、クエリに当てはまるすべてのデータを渡す。
 export const getAllPosts = async (
   atr = "createTime",
-  ope = "!=",
+  ope: FirebaseFirestore.WhereFilterOp = "!=",
   val: any = "",
   page = 0
 ) => {
-  const DB = admin.firestore();
+  const DB: FirebaseFirestore.Firestore = admin.firestore();
   const data: Post[] = [];
 
-  let ref;
+  let ref: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = await DB.collection(
+    "posts"
+  )
+    .where(atr, ope, val)
+    .orderBy("createTime", "desc");
 
   if (page == 0) {
     ref = await DB.collection("posts")
@@ -41,67 +99,40 @@ export const getAllPosts = async (
       .where(atr, ope, val)
       .limit(page_posts * (page - 1))
       .get();
-
-    ref = await DB.collection("posts")
-      .where(atr, ope, val)
-      .orderBy("createTime", "desc")
-      .startAfter(snapshot.docs[snapshot.docs.length - 1].data().createTime)
-      .limit(page_posts);
   }
 
-  await ref
+  const posts = await ref
     .get()
     .then((posts) => {
-      posts.forEach((post) => {
-        const post_data = post.data();
-        const post_tmp: Post = {
-          id: post.id,
-          title: post_data.title,
-          body: post_data.body,
-          createTime: post_data.createTime.toDate(),
-          updateTime: post_data.updateTime.toDate(),
-          tag: post_data.tag,
-          category: post_data.category,
-          public: post_data.public,
-          thumbnail: post_data.thumbnail
-            ? post_data.thumbnail
-            : "/images/no_image.png",
-        };
-        data.push(post_tmp);
-      });
+      return posts;
     })
     .catch((err) => {
       console.log(err);
     });
-  return data;
-};
 
-// idを指定して一つ記事を獲得。
-export const getPost = async (id: string) => {
-  const DB = admin.firestore();
-  const snapshot = await DB.collection("posts").doc(id).get();
-
-  //記事が存在しない場合エラーを投げる。
-  if (snapshot.empty) {
-    throw "post not found";
+  if (!posts) {
+    console.error("posts is void!!!");
+    return [];
   }
 
-  const post_data = snapshot.data();
-  const post: Post = {
-    id: snapshot.id,
-    title: post_data.title,
-    body: post_data.body,
-    createTime: post_data.createTime.toDate(),
-    updateTime: post_data.updateTime.toDate(),
-    tag: post_data.tag,
-    category: post_data.category,
-    public: post_data.public,
-    thumbnail: post_data.thumbnail
-      ? post_data.thumbnail
-      : "/images/no_image.png",
-  };
-
-  return post;
+  for (let post of posts.docs) {
+    const post_data = post.data();
+    const post_tmp: Post = {
+      id: post.id,
+      title: post_data.title,
+      body: post_data.body,
+      createTime: post_data.createTime.toDate(),
+      updateTime: post_data.updateTime.toDate(),
+      tag: await getTagsById(post_data.tag),
+      category: post_data.category,
+      public: post_data.public,
+      thumbnail: post_data.thumbnail
+        ? post_data.thumbnail
+        : "/images/no_image.png",
+    };
+    data.push(post_tmp);
+  }
+  return data;
 };
 
 // admin側で使う関数。

--- a/firebase/firebase.ts
+++ b/firebase/firebase.ts
@@ -4,22 +4,6 @@ import firebase from "firebase";
 // ここから型の定義。
 // Firebaseの方でフィールド追加したら、こちらも変更すべし。
 
-// tagは現在stringの配列として管理している。名前以外の情報を管理するようになったら、firebaseの方で参照型か、オブジェクト型にする。
-
-// 記事一覧のpathは　page/1　みたいに管理。
-// それぞれの記事のpathは posts/[id] で管理。
-export type Post = {
-  id: string;
-  title: string;
-  body: string;
-  category: string;
-  tag: string[];
-  createTime?: Date;
-  updateTime?: Date;
-  public: boolean;
-  thumbnail: string;
-};
-
 // idはルーティングに使う。そのため英語で、"/"などの記号を使わないものにする。(日本語でルーティングしてあるとコレジャナイ感すごい)
 // 例) categories/tips , categories/summary/page/2　のようにルーティング。
 export type Category = {
@@ -46,4 +30,18 @@ export type Tags = {
   id: string;
   name: string;
   children: Tag[];
+};
+
+// 記事一覧のpathは　page/1　みたいに管理。
+// それぞれの記事のpathは posts/[id] で管理。
+export type Post = {
+  id: string;
+  title: string;
+  body: string;
+  category: string;
+  tag: Tag[];
+  createTime?: Date;
+  updateTime?: Date;
+  public: boolean;
+  thumbnail: string;
 };

--- a/firebase/firebase.ts
+++ b/firebase/firebase.ts
@@ -38,7 +38,7 @@ export type Post = {
   id: string;
   title: string;
   body: string;
-  category: string;
+  category: Category;
   tag: Tag[];
   createTime?: Date;
   updateTime?: Date;

--- a/pages/tags/[id].tsx
+++ b/pages/tags/[id].tsx
@@ -11,6 +11,7 @@ import { Post, Tag, Category, Tags } from "../../firebase/firebase";
 
 export default function PostView(props) {
   const posts = JSON.parse(props.posts);
+  console.log(posts);
   const categories: Category[] = JSON.parse(props.categories);
   const tags: Tags[] = JSON.parse(props.tags);
 
@@ -48,7 +49,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     props: {
       tag: params.id,
       posts: JSON.stringify(
-        await getAllPosts("tag", "array-contains-any", [params.id], 1)
+        await getAllPosts("tag", "array-contains", params.id, 1)
       ),
       categories: JSON.stringify(await getCategories()),
       tags: JSON.stringify(await getTags()),


### PR DESCRIPTION
fixed #3 
postのcategory, tagをオブジェクト型で管理するようにし、category.id, tag.idでルーティングを行うようにした。
ただし、firebase側に変更はなく、string[], stringからTag[], Categoryへの変換はdbFanctionのgetPost, getAllPostsで行う。